### PR TITLE
Use new method canCurrentUserEdit from Lizmap 3.5

### DIFF
--- a/adresse/classes/adresse.listener.php
+++ b/adresse/classes/adresse.listener.php
@@ -47,19 +47,26 @@ class adresseListener extends jEventListener
             return;
         }
 
-        $dLayer = $layer->getEditionCapabilities();
-        $eLayer = $vlayer->getEditionCapabilities();
+        if (method_exists($vlayer, 'canCurrentUserEdit')) {
+            // Lizmap 3.5+
+            if (!$vlayer->canCurrentUserEdit()) {
+                return;
+            }
+        } else {
+            // Lizmap 3.4 and lower. DEPRECATED
+            $eLayer = $vlayer->getEditionCapabilities();
 
-        // Check if user groups intersects groups allowed by project editor
-        // If user is admin, no need to check for given groups
-        if (jAuth::isConnected() and !jAcl2::check('lizmap.admin.repositories.delete') and property_exists($eLayer, 'acl') and $eLayer->acl) {
-            // Check if configured groups white list and authenticated user groups list intersects
-            $editionGroups = $eLayer->acl;
-            $editionGroups = array_map('trim', explode(',', $editionGroups));
-            if (is_array($editionGroups) and count($editionGroups) > 0) {
-                $userGroups = jAcl2DbUserGroup::getGroups();
-                if (!array_intersect($editionGroups, $userGroups)) {
-                    return;
+            // Check if user groups intersects groups allowed by project editor
+            // If user is admin, no need to check for given groups
+            if (jAuth::isConnected() and !jAcl2::check('lizmap.admin.repositories.delete') and property_exists($eLayer, 'acl') and $eLayer->acl) {
+                // Check if configured groups white list and authenticated user groups list intersects
+                $editionGroups = $eLayer->acl;
+                $editionGroups = array_map('trim', explode(',', $editionGroups));
+                if (is_array($editionGroups) and count($editionGroups) > 0) {
+                    $userGroups = jAcl2DbUserGroup::getGroups();
+                    if (!array_intersect($editionGroups, $userGroups)) {
+                        return;
+                    }
                 }
             }
         }
@@ -150,17 +157,24 @@ class adresseListener extends jEventListener
             return;
         }
 
-        // Check if user groups intersects groups allowed by project editor
-        // If user is admin, no need to check for given groups
-        $eLayer = $layer->getEditionCapabilities();
-        if (jAuth::isConnected() and !jAcl2::check('lizmap.admin.repositories.delete') and property_exists($eLayer, 'acl') and $eLayer->acl) {
-            // Check if configured groups white list and authenticated user groups list intersects
-            $editionGroups = $eLayer->acl;
-            $editionGroups = array_map('trim', explode(',', $editionGroups));
-            if (is_array($editionGroups) and count($editionGroups) > 0) {
-                $userGroups = jAcl2DbUserGroup::getGroups();
-                if (!array_intersect($editionGroups, $userGroups)) {
-                    return;
+        if (method_exists($layer, 'canCurrentUserEdit')) {
+            // Lizmap 3.5+
+            if (!$layer->canCurrentUserEdit()) {
+                return;
+            }
+        } else {
+            // Check if user groups intersects groups allowed by project editor
+            // If user is admin, no need to check for given groups
+            $eLayer = $layer->getEditionCapabilities();
+            if (jAuth::isConnected() and !jAcl2::check('lizmap.admin.repositories.delete') and property_exists($eLayer, 'acl') and $eLayer->acl) {
+                // Check if configured groups white list and authenticated user groups list intersects
+                $editionGroups = $eLayer->acl;
+                $editionGroups = array_map('trim', explode(',', $editionGroups));
+                if (is_array($editionGroups) and count($editionGroups) > 0) {
+                    $userGroups = jAcl2DbUserGroup::getGroups();
+                    if (!array_intersect($editionGroups, $userGroups)) {
+                        return;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Lizmap 3.5 will provide  a new method to check rights of a user on an edition layer. We should use it instead of duplicating some code.

We keep the old code for Lizmap 3.4.

 
